### PR TITLE
Fix eslint resolution

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,4 @@
 module.exports = {
-  "parserOptions": {
-    "ecmaVersion": 6
-  },
+  "parserOptions": {},
   "rules": {}
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
       "workspace/*"
     ],
     "nohoist": [
+      "**/eslint",
+      "**/eslint-config-*",
+      "**/eslint-plugin-*",
       "**/husky"
     ]
   }


### PR DESCRIPTION
* ESLint walks up the directory tree and merges configs as it finds them. The `ecmaVersion` config was polluting the project config, allowing use of ES6 features like `const` and `let`.
* ESLint doesn't seem to resolve plugins/configs properly if they're dispersed between project-level `node_modules` and the hoisted `node_modules`. Prevent hoisting these so everything is resolved at the project level.