### PR TITLE
use container-start-server as the dev script

### DIFF
--- a/local-entrypoint.sh
+++ b/local-entrypoint.sh
@@ -4,7 +4,7 @@ case "$BUILD_TYPE" in
   DEV)
     echo "Running Development Environment..."
     yarn build
-    npm run start-server
+    npm run container-start-server
     ;;
   TEST)
     echo "Running Tests..."


### PR DESCRIPTION
+ uses `container-start-server` as the containerized local development script for running opensphere.